### PR TITLE
Add fastqr option to ivcrc that speeds up estimation in large samples using qrprocess 

### DIFF
--- a/ivcrc.ado
+++ b/ivcrc.ado
@@ -13,7 +13,8 @@ program ivcrc, eclass
    	DENDOG(varlist fv ts)				///
 	USERANK(varlist) 				///
 	SAVECOEF(string)				/// 
-	VARCOEF(string)  *]
+	VARCOEF(string)  ///
+	fastqr *]
 			
 if (regexm("`0'","boot")==0 & regexm("`0'","bootstrap")==0) {
 	

--- a/ivcrc.pkg
+++ b/ivcrc.pkg
@@ -1,0 +1,6 @@
+v 3
+d ivcrc Instrumental variables correlated random coefficients estimator
+d D. Benson, M. Masten, A. Torgovitsky 
+f ivcrc.ado 
+f _ivcrc_estimator.ado 
+f ivcrc.sthlp 

--- a/stata.toc
+++ b/stata.toc
@@ -1,0 +1,3 @@
+v 3
+d D. Benson, M. Masten, A. Torgovitsky 
+p ivcrc Instrumental variables correlated random coefficients estimator


### PR DESCRIPTION
Changes:
  - Adds an option fastqr to the ivcrc command.
  - Edits rank_estimate subprogram so that specifying the fastqr option will use qrprocess with its 1-step algorithm instead of qreg.

Caveats: The 1-step algorithm, though asymptotically equivalent, is not numerically equivalent to qreg's algorithm so estimates may differ in a finite sample. The 1-step algorithm also recommends using a fine grid of quantiles.

This introduces two additional dependencies:
  - qrprocess
  - moremata

See [here](https://sites.google.com/site/blaisemelly/home/computer-programs/fast) for qrprocess details